### PR TITLE
Fix issue in php 7.2 where 'Object' is now a reserved word

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -2,11 +2,11 @@
 
 namespace FastSMS\Api;
 
-use FastSMS\Object;
+use FastSMS\FastSMSObject;
 use FastSMS\Client;
 
 
-abstract class AbstractApi extends Object
+abstract class AbstractApi extends FastSMSObject
 {
 
     /**

--- a/src/FastSMSObject.php
+++ b/src/FastSMSObject.php
@@ -5,7 +5,7 @@ namespace FastSMS;
 use FastSMS\Exception\BadMethodCallException;
 use FastSMS\Exception\UnknownPropertyException;
 
-class Object
+class FastSMSObject
 {
 
     /**

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -2,9 +2,9 @@
 
 namespace FastSMS\Model;
 
-use FastSMS\Object;
+use FastSMS\FastSMSObject;
 
-class BaseModel extends Object
+class BaseModel extends FastSMSObject
 {
     /**
      * Errors container.


### PR DESCRIPTION
PHP 7.2 has introduced "Object" as a reserved word. When attempting to use the FastSMS SDK on a server running PHP 7.2 you encounter the following error:

```
Cannot use 'Object' as class name as it is reserved {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalErrorException(code: 64): Cannot use 'Object' as class name as it is reserved at /[...]/vendor/fastsms/sdk/src/Object.php:8)
```

This PR resolves this issue by changing the 'Object' class to a 'FastSMSObject'

More on reserved words: http://php.net/manual/en/reserved.other-reserved-words.php